### PR TITLE
when bodies are not logged, bodyCaptured should not be true

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -86,8 +86,8 @@ const formats = {
           delete entry.response.content
         }
 
-        entry.request.bodyCaptured = Boolean(entry.request.bodySize > 0 || ~~(entry.request.postData && entry.request.postData.text && entry.request.postData.text.length > 0))
-        entry.response.bodyCaptured = Boolean(entry.response.bodySize > 0 || ~~(entry.response.content && entry.response.content.text && entry.response.content.text.length > 0))
+        entry.request.bodyCaptured = Boolean(entry.request.postData && entry.request.postData.text && entry.request.postData.text.length > 0)
+        entry.response.bodyCaptured = Boolean(entry.response.content && entry.response.content.text && entry.response.content.text.length > 0)
 
         entry.request.bodySize = entry.request.bodySize > -1 ? entry.request.bodySize : 0
         entry.response.bodySize = entry.response.bodySize > -1 ? entry.response.bodySize : 0

--- a/test/converter.js
+++ b/test/converter.js
@@ -12,7 +12,7 @@ const options = {
 }
 
 tap.test('converter', (assert) => {
-  assert.plan(5)
+  assert.plan(6)
 
   let image = readFileSync(join(__dirname, 'fixtures', 'mashape-logo.png'))
 
@@ -51,6 +51,10 @@ tap.test('converter', (assert) => {
 
         assert.same(out, alf['1.1.0-binary'], 'should convert ALF v1.0.0 with binary data successfully')
         assert.same(binary, image, 'should manage binary data appropriately')
-      })
+      }),
+
+    Promise.resolve(converter(alf['1.0.0-without-bodies']))
+      .then((alf) => validate(alf, '1.1.0', true))
+      .then((out) => assert.same(out, alf['1.1.0-without-bodies'], 'should convert ALF v1.0.0 without body data successfully'))
   ])
 })

--- a/test/fixtures/alf/1.0.0-without-bodies.json
+++ b/test/fixtures/alf/1.0.0-without-bodies.json
@@ -1,0 +1,72 @@
+{
+  "version": "1.0.0",
+  "serviceToken": "token-foo",
+  "clientIPAddress": "10.10.10.20",
+  "environment": "PRODUCTION",
+  "har": {
+    "log": {
+      "version": "1.2",
+      "creator": {
+        "name": "galileo-agent-node",
+        "version": "1.0.0"
+      },
+      "entries": [
+        {
+          "startedDateTime": "2016-03-13T03:47:16.937Z",
+          "serverIPAddress": "10.10.10.10",
+          "time": 82,
+          "request": {
+            "method": "POST",
+            "url": "https://mockbin.org/request",
+            "httpVersion": "HTTP/1.1",
+            "queryString": [
+              { "name": "foo", "value": "bar" },
+              { "name": "baz", "value": "hey" }
+            ],
+            "headers": [
+              { "name": "accept", "value": "*/*", "comment": "" },
+              { "name": "content-length", "value": "25", "comment": "" },
+              { "name": "content-type", "value": "application/json", "comment": "" }
+            ],
+            "cookies": [
+              {
+                "name": "foo",
+                "expires": "2015-02-10T07:33:17.146Z",
+                "value": "bar",
+                "httpOnly": false,
+                "secure": false
+              }
+            ],
+            "headersSize": 62,
+            "bodySize": 24
+          },
+          "response": {
+            "status": 200,
+            "statusText": "OK",
+            "httpVersion": "HTTP/1.1",
+            "headers": [
+              { "name": "content-length", "value": "25" },
+              { "name": "content-type",   "value": "application/json; charset=utf-8" },
+              { "name": "x-powered-by",   "value": "mockbin" }
+            ],
+            "cookies": [],
+            "redirectURL": "",
+            "headersSize": 87,
+            "bodySize": 25
+          },
+          "cache": {},
+          "timings": {
+            "blocked": -1,
+            "dns": -1,
+            "connect": -1,
+            "send": 0.06,
+            "wait": 87.26,
+            "receive": 0.24,
+            "ssl": -1
+          },
+          "connection": "3178207"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/alf/1.1.0-without-bodies.json
+++ b/test/fixtures/alf/1.1.0-without-bodies.json
@@ -1,0 +1,58 @@
+{
+  "version": "1.1.0",
+  "serviceToken": "token-foo",
+  "environment": "PRODUCTION",
+  "har": {
+    "log": {
+      "creator": {
+        "name": "galileo-agent-node",
+        "version": "1.0.0"
+      },
+      "entries": [
+        {
+          "startedDateTime": "2016-03-13T03:47:16.937Z",
+          "serverIPAddress": "10.10.10.10",
+          "clientIPAddress": "10.10.10.20",
+          "time": 82,
+          "request": {
+            "method": "POST",
+            "url": "https://mockbin.org/request",
+            "httpVersion": "HTTP/1.1",
+            "queryString": [
+              { "name": "foo", "value": "bar" },
+              { "name": "baz", "value": "hey" }
+            ],
+            "headers": [
+              { "name": "accept", "value": "*/*" },
+              { "name": "content-length", "value": "25" },
+              { "name": "content-type", "value": "application/json" }
+            ],
+            "headersSize": 62,
+            "bodyCaptured": false,
+            "bodySize": 24
+          },
+          "response": {
+            "status": 200,
+            "statusText": "OK",
+            "httpVersion": "HTTP/1.1",
+            "headers": [
+              { "name": "content-length", "value": "25" },
+              { "name": "content-type",   "value": "application/json; charset=utf-8" },
+              { "name": "x-powered-by",   "value": "mockbin" }
+            ],
+            "headersSize": 87,
+            "bodyCaptured": false,
+            "bodySize": 25
+          },
+          "timings": {
+            "blocked": -1,
+            "connect": -1,
+            "send": 0.06,
+            "wait": 87.26,
+            "receive": 0.24
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/alf/index.js
+++ b/test/fixtures/alf/index.js
@@ -4,6 +4,8 @@ import oneoneoh from './1.1.0.json'
 import twoohoh from './2.0.0.json'
 import oneohohbinary from './1.0.0-binary.json'
 import oneoneohbinary from './1.1.0-binary.json'
+import oneohohwithoutbodies from './1.0.0-without-bodies.json'
+import oneoneohwithoutbodies from './1.1.0-without-bodies.json'
 
 export default {
   '0.0.1': ohohone,
@@ -11,5 +13,7 @@ export default {
   '1.1.0': oneoneoh,
   '1.0.0-binary': oneohohbinary,
   '1.1.0-binary': oneoneohbinary,
+  '1.0.0-without-bodies': oneohohwithoutbodies,
+  '1.1.0-without-bodies': oneoneohwithoutbodies,
   '2.0.0': twoohoh
 }


### PR DESCRIPTION
Sending an ALF without request and response bodies is incorrectly setting `bodyCaptured: true`. Note that ALFs without bodies will still have a bodySize.

Changes:
- update logic for bodyCaptured
- added unit tests to ensure alfs without bodies are handled correctly
